### PR TITLE
Add initial WPF Plant Doctor prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+history.db
+*.user
+*.vs/

--- a/PlantDoctorApp/App.xaml
+++ b/PlantDoctorApp/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="PlantDoctorApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/PlantDoctorApp/App.xaml.cs
+++ b/PlantDoctorApp/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace PlantDoctorApp
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/PlantDoctorApp/HistoryService.cs
+++ b/PlantDoctorApp/HistoryService.cs
@@ -1,0 +1,59 @@
+using Microsoft.Data.Sqlite;
+using System.Collections.Generic;
+
+namespace PlantDoctorApp
+{
+    public class HistoryItem
+    {
+        public string ImagePath { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Condition { get; set; } = "";
+        public string Advice { get; set; } = "";
+    }
+
+    public class HistoryService
+    {
+        private readonly string _dbPath = "history.db";
+
+        public HistoryService()
+        {
+            using var db = new SqliteConnection($"Data Source={_dbPath}");
+            db.Open();
+            var cmd = db.CreateCommand();
+            cmd.CommandText = "CREATE TABLE IF NOT EXISTS history (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT, name TEXT, condition TEXT, advice TEXT);";
+            cmd.ExecuteNonQuery();
+        }
+
+        public void SaveResult(string path, string name, string condition, string advice)
+        {
+            using var db = new SqliteConnection($"Data Source={_dbPath}");
+            db.Open();
+            var cmd = db.CreateCommand();
+            cmd.CommandText = "INSERT INTO history (path, name, condition, advice) VALUES ($p, $n, $c, $a);";
+            cmd.Parameters.AddWithValue("$p", path);
+            cmd.Parameters.AddWithValue("$n", name);
+            cmd.Parameters.AddWithValue("$c", condition);
+            cmd.Parameters.AddWithValue("$a", advice);
+            cmd.ExecuteNonQuery();
+        }
+
+        public IEnumerable<HistoryItem> LoadHistory()
+        {
+            using var db = new SqliteConnection($"Data Source={_dbPath}");
+            db.Open();
+            var cmd = db.CreateCommand();
+            cmd.CommandText = "SELECT path, name, condition, advice FROM history ORDER BY id DESC";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                yield return new HistoryItem
+                {
+                    ImagePath = reader.GetString(0),
+                    Name = reader.GetString(1),
+                    Condition = reader.GetString(2),
+                    Advice = reader.GetString(3)
+                };
+            }
+        }
+    }
+}

--- a/PlantDoctorApp/MainWindow.xaml
+++ b/PlantDoctorApp/MainWindow.xaml
@@ -1,0 +1,27 @@
+<Window x:Class="PlantDoctorApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Plant Doctor" Height="450" Width="800"
+        WindowStartupLocation="CenterScreen">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Grid.Row="0" HorizontalAlignment="Right" Margin="0 0 0 10">
+            <TextBlock Text="Language:" VerticalAlignment="Center" Margin="0 0 5 0"/>
+            <ComboBox x:Name="LanguageSelector" Width="100" SelectionChanged="LanguageSelector_SelectionChanged">
+                <ComboBoxItem Tag="en" IsSelected="True">English</ComboBoxItem>
+                <ComboBoxItem Tag="de">Deutsch</ComboBoxItem>
+            </ComboBox>
+        </StackPanel>
+        <Border Grid.Row="1" AllowDrop="True" Drop="ImageDrop" Background="#f0f0f0" BorderBrush="#ccc" BorderThickness="2" CornerRadius="4" Padding="10">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" x:Name="DropArea">
+                <TextBlock Text="Drag images here" HorizontalAlignment="Center" Margin="0 0 0 10"/>
+                <Button Content="Select Images" Click="SelectImages_Click" Width="120"/>
+            </StackPanel>
+        </Border>
+        <ListBox x:Name="HistoryList" Grid.Row="2" Margin="0 10 0 0" Height="150"/>
+    </Grid>
+</Window>

--- a/PlantDoctorApp/MainWindow.xaml.cs
+++ b/PlantDoctorApp/MainWindow.xaml.cs
@@ -1,0 +1,65 @@
+using Microsoft.Win32;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PlantDoctorApp
+{
+    public partial class MainWindow : Window
+    {
+        private readonly PlantClassifierService _classifier = new PlantClassifierService();
+        private readonly OpenAIService _openai = new OpenAIService();
+        private readonly HistoryService _history = new HistoryService();
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            LoadHistory();
+        }
+
+        private void LanguageSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            // TODO: implement language switching
+        }
+
+        private void ImageDrop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                AnalyzeFiles(files);
+            }
+        }
+
+        private void SelectImages_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFileDialog { Filter = "Image Files|*.png;*.jpg;*.jpeg", Multiselect = true };
+            if (dlg.ShowDialog() == true)
+            {
+                AnalyzeFiles(dlg.FileNames);
+            }
+        }
+
+        private async void AnalyzeFiles(IEnumerable<string> files)
+        {
+            int count = 0;
+            foreach (var file in files)
+            {
+                if (count >= 2) break;
+                var plant = _classifier.Classify(file);
+                var advice = await _openai.GetAdviceAsync(plant.Name, plant.Condition);
+                _history.SaveResult(file, plant.Name, plant.Condition, advice);
+                HistoryList.Items.Insert(0, $"{plant.Name} - {plant.Condition}");
+                count++;
+            }
+        }
+
+        private void LoadHistory()
+        {
+            foreach (var item in _history.LoadHistory())
+            {
+                HistoryList.Items.Add($"{item.Name} - {item.Condition}");
+            }
+        }
+    }
+}

--- a/PlantDoctorApp/OpenAIService.cs
+++ b/PlantDoctorApp/OpenAIService.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using OpenAI_API;
+
+namespace PlantDoctorApp
+{
+    public class OpenAIService
+    {
+        private readonly OpenAIAPI _api;
+
+        public OpenAIService()
+        {
+            var key = System.Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+            _api = new OpenAIAPI(key);
+        }
+
+        public async Task<string> GetAdviceAsync(string plantName, string condition)
+        {
+            string prompt = $"Provide care advice for {plantName} with condition {condition}.";
+            var result = await _api.Chat.CreateChatCompletionAsync(new OpenAI_API.Chat.ChatRequest()
+            {
+                Model = OpenAI_API.Models.Model.GPT4,
+                Temperature = 0.7,
+                MaxTokens = 100,
+                Messages = new System.Collections.Generic.List<OpenAI_API.Chat.ChatMessage>
+                {
+                    new OpenAI_API.Chat.ChatMessage(OpenAI_API.Chat.ChatMessageRole.User, prompt)
+                }
+            });
+            return result.Choices[0].Message.Content.Trim();
+        }
+    }
+}

--- a/PlantDoctorApp/Plant.cs
+++ b/PlantDoctorApp/Plant.cs
@@ -1,0 +1,4 @@
+namespace PlantDoctorApp
+{
+    public record Plant(string Name, string Condition);
+}

--- a/PlantDoctorApp/PlantClassifierService.cs
+++ b/PlantDoctorApp/PlantClassifierService.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PlantDoctorApp
+{
+    public class PlantClassifierService
+    {
+        public Plant Classify(string imagePath)
+        {
+            // TODO: integrate TensorFlow model here
+            // For now, return dummy data
+            string name = "Unknown Plant";
+            string condition = "Unknown";
+            return new Plant(name, condition);
+        }
+    }
+}

--- a/PlantDoctorApp/PlantDoctorApp.csproj
+++ b/PlantDoctorApp/PlantDoctorApp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.0" />
+    <PackageReference Include="OpenAI" Version="1.6.1" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.10.0" />
+    <PackageReference Include="TensorFlow.NET" Version="0.110.0" />
+  </ItemGroup>
+</Project>

--- a/PlantDoctorApp/PlantDoctorApp.sln
+++ b/PlantDoctorApp/PlantDoctorApp.sln
@@ -1,0 +1,19 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlantDoctorApp", "PlantDoctorApp.csproj", "{8AEDB6C5-11DE-4A3A-B108-BEF7D8E0173B}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{8AEDB6C5-11DE-4A3A-B108-BEF7D8E0173B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{8AEDB6C5-11DE-4A3A-B108-BEF7D8E0173B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{8AEDB6C5-11DE-4A3A-B108-BEF7D8E0173B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{8AEDB6C5-11DE-4A3A-B108-BEF7D8E0173B}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# plant-doctor-app
+# Plant Doctor App
+
+This repository contains a minimal WPF application written in C# (.NET 6) that demonstrates a basic "Plant Doctor" prototype. The app allows users to drag and drop up to two images of plants. Each image is classified locally (placeholder implementation) and the result is sent to the OpenAI API to generate care advice. All analyses are stored in a local SQLite database and shown in the history list.
+
+## Building
+1. Install **Visual Studio 2022** or later with the **.NET Desktop Development** workload.
+2. Clone this repository and open `PlantDoctorApp.sln`.
+3. Ensure your system has the **.NET 6 SDK** installed.
+4. Set the configuration to `Release` and build the solution. The compiled application will appear in `PlantDoctorApp/bin/Release/net6.0-windows/`.
+
+## Running
+Before starting the app you must set the environment variable `OPENAI_API_KEY` with your API key. The app uses this to request care advice from the OpenAI API.
+
+```
+set OPENAI_API_KEY=your-key-here
+```
+
+After building, run `PlantDoctorApp.exe`. Drag images onto the drop area or use the button to select files. A simple history is shown at the bottom of the window.
+
+## Notes
+The plant classification service currently returns placeholder data. To integrate a real model you can extend `PlantClassifierService` using TensorFlow.NET and a trained model.


### PR DESCRIPTION
## Summary
- add WPF project with main window, services and solution file
- implement dummy plant classifier and GPT based advice provider
- store analysis history in SQLite
- document build and run steps

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d413195148329a0ce24b2df45905e